### PR TITLE
Add podman-entitlement GitHub Action.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository contains the common Actions and config files for developing the 
 - [action-io-generator](./action-io-generator) is an NPM package and Docker Action that generates TypeScript enums matching the Inputs and Outputs defined in your `action.yml`.
 - [bundle-verifier](./bundle-verifier) is a JavaScript Action that makes sure your JavaScript action's committed distribution bundle is up-to-date.
 - [commit-data](./commit-data) is a Docker Action that outputs some commonly needed data about the current workflow's HEAD commit.
+- [podman-entitlement](./podman-entitlement) is a composite Action which enables subsequent `podman build`s to consume Red Hat entitlements.
 - [config-files](./config-files) contains our shared TypeScript, ESLint, and Webpack configs.
 
 It is also used for tracking issues that don't fit into another, more specific repository.

--- a/podman-entitlement/README.md
+++ b/podman-entitlement/README.md
@@ -1,0 +1,43 @@
+## Podman Entitlement GitHub Action
+
+When building container images that install Red Hat content
+which is not part of Universal Base Image repositories,
+Red Hat entitlements are needed to access the full Red Hat Enterprise Linux
+repositories.
+
+To avoid modifying the Dockerfiles with extra steps that would
+handle the registration, this Action registers a temporary system
+using organization's activation key, and uses `/etc/containers/mounts.conf`
+to configure subsequent `podman build` invocations to have access
+to the entitlements.
+
+## Inputs
+
+| Input | Description |
+| ---   | --- |
+| `org` | Red Hat account organization |
+| `activationkey` | Red Hat account activation key |
+| `image` | Container image to use to run `subscription-manager register` with the above parameters <br> Optional, defaults to `registry.access.redhat.com/ubi10` |
+
+## Usage
+
+On https://access.redhat.com/management/activation_keys, create
+new Subscription Manager activation key.
+
+Set up secrets in your repository, for example `redhat_org` for your
+Red Hat account organization and `redhat_activationkey` for your Red Hat
+account activation key. Your Organization ID is shown on the above-mentioned
+Activation Keys page on Red Hat portal.
+
+In your workflow YAML which calls `podman build`, add invocation
+of `redhat-actions/common/podman-entitlement` before that `podman build`
+step:
+
+```yaml
+      - uses: redhat-actions/common/podman-entitlement
+        with:
+          org: ${{ secrets.redhat_org }}
+          activationkey: ${{ secrets.redhat_activationkey }}
+      - run: podman build -t localhost/the-image:the-tag src
+```
+

--- a/podman-entitlement/action.yml
+++ b/podman-entitlement/action.yml
@@ -1,0 +1,32 @@
+name: 'Enable Red Hat entitled podman builds'
+inputs:
+  org:
+    description: 'Red Hat account organization'
+  activationkey:
+    description: 'Red Hat account activation key'
+  image:
+    description: 'Container image to use to run subscription-manager register'
+    default: 'registry.access.redhat.com/ubi10'
+runs:
+  using: 'composite'
+  steps:
+    - run: mkdir -p /tmp/{etc-pki-entitlement,rhsm}-${{ github.run_id }}
+      shell: bash
+    - run: |
+        NAME=$( echo "$run_url" | sed 's#^https://##;s#/#-#g' )
+        podman run --rm --name="$NAME" \
+          -v "/tmp/etc-pki-entitlement-${{ github.run_id }}":/etc/pki/entitlement-out:z \
+          -v "/tmp/rhsm-${{ github.run_id }}":/etc/rhsm-out:z \
+          "${{ inputs.image }}" \
+          bash -c '/usr/sbin/subscription-manager register \
+                     --org="${{ inputs.org }}" \
+                     --activationkey="${{ inputs.activationkey }}" \
+                     --name="'$NAME'" \
+                   && cp /etc/pki/entitlement/* /etc/pki/entitlement-out/ \
+                   && cp -r /etc/rhsm/ca /etc/rhsm/rhsm.conf /etc/rhsm-out \
+                   && /usr/sbin/subscription-manager unregister'
+      env:
+        run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      shell: bash
+    - run: for i in etc-pki-entitlement rhsm ; do echo "/tmp/$i-${{ github.run_id }}:/run/secrets/$i" ; done | sudo tee -a /etc/containers/mounts.conf
+      shell: bash

--- a/podman-entitlement/action.yml
+++ b/podman-entitlement/action.yml
@@ -31,8 +31,8 @@ runs:
                      --activationkey="$SM_KEY" \
                      --name="$SYSTEM_NAME" \
                    && cp /etc/pki/entitlement/* /etc/pki/entitlement-out/ \
-                   && cp -r /etc/rhsm/ca /etc/rhsm/rhsm.conf /etc/rhsm-out \
-                   && /usr/sbin/subscription-manager unregister'
+                   && cp -r /etc/rhsm/ca /etc/rhsm/rhsm.conf /etc/rhsm-out ; \
+                   /usr/sbin/subscription-manager unregister'
       env:
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         RUN_ID: ${{ github.run_id }}

--- a/podman-entitlement/action.yml
+++ b/podman-entitlement/action.yml
@@ -17,11 +17,12 @@ runs:
         podman run --rm --name="$NAME" \
           -v "/tmp/etc-pki-entitlement-${{ github.run_id }}":/etc/pki/entitlement-out:z \
           -v "/tmp/rhsm-${{ github.run_id }}":/etc/rhsm-out:z \
+          -e SYSTEM_NAME="$NAME" \
           "${{ inputs.image }}" \
           bash -c '/usr/sbin/subscription-manager register \
                      --org="${{ inputs.org }}" \
                      --activationkey="${{ inputs.activationkey }}" \
-                     --name="'$NAME'" \
+                     --name="$SYSTEM_NAME" \
                    && cp /etc/pki/entitlement/* /etc/pki/entitlement-out/ \
                    && cp -r /etc/rhsm/ca /etc/rhsm/rhsm.conf /etc/rhsm-out \
                    && /usr/sbin/subscription-manager unregister'

--- a/podman-entitlement/action.yml
+++ b/podman-entitlement/action.yml
@@ -1,9 +1,12 @@
 name: 'Enable Red Hat entitled podman builds'
+description: 'Register a temporary system with Red Hat subscription and configure podman to use the entitlements'
 inputs:
   org:
     description: 'Red Hat account organization'
+    required: true
   activationkey:
     description: 'Red Hat account activation key'
+    required: true
   image:
     description: 'Container image to use to run subscription-manager register'
     default: 'registry.access.redhat.com/ubi10'

--- a/podman-entitlement/action.yml
+++ b/podman-entitlement/action.yml
@@ -10,24 +10,34 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - run: mkdir -p /tmp/{etc-pki-entitlement,rhsm}-${{ github.run_id }}
+    - run: mkdir -p /tmp/{etc-pki-entitlement,rhsm}-"${RUN_ID}"
+      env:
+        RUN_ID: ${{ github.run_id }}
       shell: bash
     - run: |
-        NAME=$( echo "$run_url" | sed 's#^https://##;s#/#-#g' )
+        NAME=$( echo "$RUN_URL" | sed 's#^https://##;s#/#-#g' )
         podman run --rm --name="$NAME" \
-          -v "/tmp/etc-pki-entitlement-${{ github.run_id }}":/etc/pki/entitlement-out:z \
-          -v "/tmp/rhsm-${{ github.run_id }}":/etc/rhsm-out:z \
+          -v "/tmp/etc-pki-entitlement-${RUN_ID}":/etc/pki/entitlement-out:z \
+          -v "/tmp/rhsm-${RUN_ID}":/etc/rhsm-out:z \
+          -e SM_ORG="$INPUTS_ORG" \
+          -e SM_KEY="$INPUTS_ACTIVATIONKEY" \
           -e SYSTEM_NAME="$NAME" \
-          "${{ inputs.image }}" \
+          "$INPUTS_IMAGE" \
           bash -c '/usr/sbin/subscription-manager register \
-                     --org="${{ inputs.org }}" \
-                     --activationkey="${{ inputs.activationkey }}" \
+                     --org="$SM_ORG" \
+                     --activationkey="$SM_KEY" \
                      --name="$SYSTEM_NAME" \
                    && cp /etc/pki/entitlement/* /etc/pki/entitlement-out/ \
                    && cp -r /etc/rhsm/ca /etc/rhsm/rhsm.conf /etc/rhsm-out \
                    && /usr/sbin/subscription-manager unregister'
       env:
-        run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        RUN_ID: ${{ github.run_id }}
+        INPUTS_IMAGE: ${{ inputs.image }}
+        INPUTS_ORG: ${{ inputs.org }}
+        INPUTS_ACTIVATIONKEY: ${{ inputs.activationkey }}
       shell: bash
-    - run: for i in etc-pki-entitlement rhsm ; do echo "/tmp/$i-${{ github.run_id }}:/run/secrets/$i" ; done | sudo tee -a /etc/containers/mounts.conf
+    - run: for i in etc-pki-entitlement rhsm ; do echo "/tmp/$i-${RUN_ID}:/run/secrets/$i" ; done | sudo tee -a /etc/containers/mounts.conf
+      env:
+        RUN_ID: ${{ github.run_id }}
       shell: bash


### PR DESCRIPTION
### Description

When building images that need Red Hat content beyond what is available in the Universal Base Image repositories, Red Hat subscription is needed. To avoid changing the Dockerfile and invoke `subscription-manager register` manually, this GitHub Actions calls that step in separate temporary container and uses `/etc/containers/mounts.conf` to configure subsequent `podman build` invocations to have access to the entitlements.

Note that for example `registry.access.redhat.com/ubi9-minimal` does not have `subscription-manager` at all so the approach with tweaking the Dockerfile and somehow passing the subscription credentials to the `podman build` invocation which gets sometimes recommended would not work with those minimalistic images at all.

### Related Issue(s)

* https://github.com/redhat-actions/common/issues/32

### Checklist

- [ ] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

- Add new GitHub Action `podman-entitlement`
