### PR TITLE
Update GitHub Action checkout from v2 to v6

### DIFF
--- a/.github/workflows/ci-action-io-generator.yml
+++ b/.github/workflows/ci-action-io-generator.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - run: npm ci
       - run: npm run lint
   
@@ -26,7 +26,7 @@ jobs:
       BUNDLE_COMMAND: "npm run bundle"
       WORKDIR: "./action-io-generator"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Install
         working-directory: ${{ env.WORKDIR }}
@@ -46,7 +46,7 @@ jobs:
       TEST_FILE: test/generated/inputs-outputs.ts
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/ci-commit-data.yml
+++ b/.github/workflows/ci-commit-data.yml
@@ -11,7 +11,7 @@ jobs:
       tag: ${{ steps.commit_data.outputs.tag }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Run commit-data
         id: commit_data

--- a/.github/workflows/verify-verifier.yml
+++ b/.github/workflows/verify-verifier.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Install
       working-directory: ${{ env.WORKDIR }}


### PR DESCRIPTION
Fixes deprecation warning that Node20.js will stop working in June.

### Description
Update GitHub Action checkout from v2 to v6

### Related Issue(s)
none

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [x] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [x] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made
Incread used version in Github workflow files
