### PR TITLE
Add community files and AI agent documentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Dockerfile]
+indent_size = 4
+
+[*.sh]
+indent_size = 4

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "npm"
+    directory: "/action-io-generator"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "npm"
+    directory: "/bundle-verifier"
+    schedule:
+      interval: "monthly"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,100 @@
+# AI Agent Guide
+
+This document helps AI coding agents understand and work with this repository effectively.
+
+## Repository Overview
+
+This is a monorepo for shared GitHub Actions and configuration used by the [Red Hat GitHub Actions](https://github.com/redhat-actions) organization. It contains four components that are independently developed but share a common repository.
+
+## Components
+
+### action-io-generator (`./action-io-generator/`)
+
+An npm package and Docker-based GitHub Action that reads an `action.yml` file and generates TypeScript enums for its inputs and outputs.
+
+- **Language:** TypeScript
+- **Bundler:** Webpack (shared config from `config-files/webpack`)
+- **Entry point:** `src/index.ts` (library), `bin.js` (CLI)
+- **Key commands:**
+  ```sh
+  cd action-io-generator
+  npm ci
+  npm run lint          # ESLint with --max-warnings=0
+  npm run compile       # tsc -p .
+  npm run bundle        # Webpack production build + copy bin.js to dist/
+  npm run test-cli      # Generate enums from test/test.action.yml
+  ```
+- **Important:** The `dist/` directory is committed. After source changes, run `npm run bundle` and commit the updated dist.
+
+### bundle-verifier (`./bundle-verifier/`)
+
+A JavaScript GitHub Action that verifies a committed distribution bundle matches a fresh build from source.
+
+- **Language:** TypeScript
+- **Bundler:** `@vercel/ncc`
+- **Runtime:** Node.js (specified in `action.yml` `runs.using`)
+- **Key commands:**
+  ```sh
+  cd bundle-verifier
+  npm ci
+  npm run compile       # tsc -p .
+  npm run bundle        # ncc build src/index.ts --source-map --minify
+  ```
+- **Important:** The `dist/` directory is committed. After source changes, run `npm run bundle` and commit the updated dist.
+
+### commit-data (`./commit-data/`)
+
+A Docker-based GitHub Action that extracts commonly needed data about the HEAD commit (branch, SHA, tags, PR info).
+
+- **Language:** Shell (bash)
+- **Container:** Alpine Linux with git
+- **Entry point:** `entrypoint.sh`
+- **No build step required** — changes to `entrypoint.sh` or `Dockerfile` take effect directly.
+- **Outputs are set via:** `echo "name=value" >> "$GITHUB_OUTPUT"`
+
+### config-files (`./config-files/`)
+
+Shared npm configuration packages consumed by other `redhat-actions` repos:
+
+| Package | Purpose |
+|---------|---------|
+| `@redhat-actions/tsconfig` | Base TypeScript configuration |
+| `@redhat-actions/eslint-config` | ESLint rules (extends airbnb-base + typescript-eslint) |
+| `@redhat-actions/webpack-config` | Webpack 5 config factory for bundling actions |
+
+These are published to npm and have downstream consumers. Changes here affect all repos that depend on them.
+
+## Code Conventions
+
+- **TypeScript strict mode** is enabled across all components
+- **4-space indentation**, double quotes, 120-character max line length
+- **Stroustrup brace style** (`else` on new line)
+- **ESLint** with `@redhat-actions/eslint-config` — run with `--max-warnings=0`
+- **No default exports** — use named exports
+- **Explicit return types** on functions
+
+## CI Workflows
+
+Located in `.github/workflows/`:
+
+| Workflow | What it tests |
+|----------|---------------|
+| `ci-action-io-generator.yml` | Lint, bundle verification, compile + CLI test |
+| `ci-commit-data.yml` | Runs the commit-data action and echoes outputs |
+| `verify-verifier.yml` | Bundle-verifier verifies its own dist is current |
+
+## Making Changes
+
+1. **Source changes to actions:** Edit TypeScript source, then run `npm run bundle` to regenerate `dist/`. Commit both source and dist changes together.
+2. **Config file changes:** Edit the config, bump the version in `package.json`. Consider impact on downstream consumers.
+3. **Shell script changes (commit-data):** Edit `entrypoint.sh` directly. Ensure POSIX compatibility is not required (the script uses bash).
+4. **Workflow changes:** Edit YAML files in `.github/workflows/`. Use pinned runner versions and action version tags.
+
+## Testing
+
+There is no formal test suite. Verification is done through:
+- `npm run lint` — static analysis
+- `npm run compile` — type checking
+- `npm run bundle` — confirms the code bundles successfully
+- `npm run test-cli` — (action-io-generator only) runs the CLI against a test action.yml
+- CI workflows — end-to-end verification via GitHub Actions

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at the
+[Red Hat Actions](https://github.com/redhat-actions) organization.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to Red Hat Actions Common
+
+Thank you for your interest in contributing to the Red Hat GitHub Actions project!
+
+## Getting Started
+
+1. **Open an issue first** — before submitting a non-trivial pull request, please [open an issue](https://github.com/redhat-actions/common/issues) to discuss the change.
+2. **Fork the repository** and create a feature branch from `main`.
+3. Make your changes, following the conventions below.
+4. Submit a pull request against `main`.
+
+## Repository Structure
+
+This is a monorepo containing several components:
+
+| Component | Type | Description |
+|-----------|------|-------------|
+| [action-io-generator](./action-io-generator) | npm package + Docker Action | Generates TypeScript enums from `action.yml` inputs/outputs |
+| [bundle-verifier](./bundle-verifier) | JavaScript Action | Verifies committed dist bundles are up-to-date |
+| [commit-data](./commit-data) | Docker Action | Extracts HEAD commit metadata as action outputs |
+| [config-files](./config-files) | npm packages | Shared TypeScript, ESLint, and Webpack configurations |
+
+## Development
+
+### Prerequisites
+
+- Node.js 20+
+- npm
+
+### Common Commands
+
+Each JavaScript component uses the same npm script conventions:
+
+```sh
+npm ci                # Install dependencies
+npm run compile       # Compile TypeScript
+npm run bundle        # Build distribution bundle
+npm run lint          # Run ESLint (--max-warnings=0)
+npm run clean         # Remove build artifacts
+```
+
+### Bundle Verification
+
+JavaScript actions commit their bundled `dist/` directory. After making source changes:
+
+1. Run `npm run bundle` to regenerate the dist.
+2. Commit the updated `dist/` alongside your source changes.
+3. CI will verify the committed bundle matches a fresh build.
+
+### Config Files
+
+The shared config packages (`@redhat-actions/tsconfig`, `@redhat-actions/eslint-config`, `@redhat-actions/webpack-config`) are consumed by other repos in the `redhat-actions` organization. Changes to these packages affect all downstream consumers — please consider backwards compatibility.
+
+## Code Style
+
+- TypeScript with strict mode enabled
+- 4-space indentation, double quotes, 120-character line limit
+- ESLint with the shared `@redhat-actions/eslint-config`
+- See [config-files/eslint](./config-files/eslint) for the full ruleset
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This repository contains the common Actions and config files for developing the Red Hat GitHub Actions.
 
-- [action-io-generator](./action-io-generator) is an NPM package and (soon to be) Docker Action that makes sure your JavaScript action uses the same Inputs and Outputs defined in your `action.yml`.
+- [action-io-generator](./action-io-generator) is an NPM package and Docker Action that generates TypeScript enums matching the Inputs and Outputs defined in your `action.yml`.
 - [bundle-verifier](./bundle-verifier) is a JavaScript Action that makes sure your JavaScript action's committed distribution bundle is up-to-date.
 - [commit-data](./commit-data) is a Docker Action that outputs some commonly needed data about the current workflow's HEAD commit.
 - [config-files](./config-files) contains our shared TypeScript, ESLint, and Webpack configs.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,4 +17,4 @@ Please include:
 
 ## Response
 
-We will acknowledge receipt of your report within 3 business days and aim to provide a detailed response within 10 business days, including an assessment and planned timeline for a fix.
+We will review your report and respond with an assessment and planned timeline for a fix.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do not open a public issue for security vulnerabilities.**
+
+Instead, please report security issues by emailing the maintainers at the addresses listed in the [Red Hat Actions organization security policy](https://github.com/redhat-actions/.github/blob/main/SECURITY.md).
+
+Please include:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Any potential impact
+- Suggested fix (if you have one)
+
+## Response
+
+We will acknowledge receipt of your report within 3 business days and aim to provide a detailed response within 10 business days, including an assessment and planned timeline for a fix.


### PR DESCRIPTION
## Summary

- Add standard community health files: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1), `SECURITY.md`
- Add `.editorconfig` matching the project's existing ESLint conventions (4-space indent, UTF-8, LF)
- Add `.github/dependabot.yml` for automated dependency updates (npm + GitHub Actions, monthly)
- Add `AGENTS.md` to help AI coding agents navigate the monorepo structure, understand build commands, and follow project conventions
- Fix outdated README wording for action-io-generator ("soon to be" Docker Action → it already is one)

## Test plan

- [ ] Verify community files render correctly on GitHub
- [ ] Verify Dependabot begins creating PRs after merge
- [ ] Verify AGENTS.md accurately describes the repo structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)