### PR TITLE
Fix commit-data entrypoint not found on Alpine 3.21

### DIFF
--- a/commit-data/Dockerfile
+++ b/commit-data/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.21
 
-RUN apk add --no-cache git
+RUN apk add --no-cache git bash
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh
 
-ENTRYPOINT /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/commit-data/entrypoint.sh
+++ b/commit-data/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+git config --global --add safe.directory /github/workspace
+
 if [[ -n "${INPUT_WORKING_DIRECTORY:-}" ]]; then
     echo "Working directory is $INPUT_WORKING_DIRECTORY"
     cd "$INPUT_WORKING_DIRECTORY"


### PR DESCRIPTION
## Summary
- Add `bash` to Alpine package install — Alpine 3.21 no longer ships bash by default, but the entrypoint script uses bash features (`pipefail`, `[[ ]]`)
- Switch `ENTRYPOINT` to JSON form to avoid shell wrapping issues

This fixes the "Get Commit Data" CI check which is currently failing on every PR.

## Test plan
- [ ] CI "Get Commit Data" check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)