### PR TITLE
Improve CI workflows

### DIFF
--- a/.github/workflows/ci-action-io-generator.yml
+++ b/.github/workflows/ci-action-io-generator.yml
@@ -2,7 +2,18 @@
 name: action-io-generator CI
 on:
   push:
+    branches: [main]
+    paths:
+      - 'action-io-generator/**'
+      - '.github/workflows/ci-action-io-generator.yml'
   pull_request:
+    paths:
+      - 'action-io-generator/**'
+      - '.github/workflows/ci-action-io-generator.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 defaults:
   run:
@@ -15,6 +26,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - run: npm ci
       - run: npm run lint
 
@@ -27,18 +41,21 @@ jobs:
       WORKDIR: "./action-io-generator"
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
 
       - name: Install
         working-directory: ${{ env.WORKDIR }}
         run: npm ci
 
       - name: Verify Latest Bundle
-        uses: redhat-actions/common/bundle-verifier@v1
+        uses: ./bundle-verifier
         with:
           bundle_file: ${{ env.BUNDLE_FILE }}
           bundle_command: ${{ env.BUNDLE_COMMAND }}
           working_directory: ${{ env.WORKDIR }}
-  
+
   compile_test:
     name: Compile and test
     runs-on: ubuntu-24.04
@@ -47,9 +64,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
 
       - run: npm ci
-      - run: npm run lint
       - run: npm run compile
       - run: npm run bundle
 

--- a/.github/workflows/ci-commit-data.yml
+++ b/.github/workflows/ci-commit-data.yml
@@ -1,7 +1,18 @@
 name: commit-data CI
 on:
   push:
+    branches: [main]
+    paths:
+      - 'commit-data/**'
+      - '.github/workflows/ci-commit-data.yml'
   pull_request:
+    paths:
+      - 'commit-data/**'
+      - '.github/workflows/ci-commit-data.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   commit_data:

--- a/.github/workflows/verify-verifier.yml
+++ b/.github/workflows/verify-verifier.yml
@@ -1,7 +1,18 @@
 name: bundle-verifier CI
 on:
   push:
+    branches: [main]
+    paths:
+      - 'bundle-verifier/**'
+      - '.github/workflows/verify-verifier.yml'
   pull_request:
+    paths:
+      - 'bundle-verifier/**'
+      - '.github/workflows/verify-verifier.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   BUNDLE_FILE: "dist/index.js"
@@ -15,6 +26,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 24
 
     - name: Install
       working-directory: ${{ env.WORKDIR }}


### PR DESCRIPTION
## Summary

- **Branch filters** — `push` triggers only on `main` to prevent duplicate CI runs for pull requests
- **Path filters** — each workflow only triggers when its own component files or workflow file change
- **Concurrency control** — superseded runs are automatically cancelled via `cancel-in-progress`
- **Node.js pinning** — all Node.js jobs use `actions/setup-node@v4` with `node-version: 24`
- **Local bundle-verifier** — `check-dist` job now uses `./bundle-verifier` instead of `redhat-actions/common/bundle-verifier@v1`, testing against current source rather than a published tag
- **Remove redundant lint** — `compile_test` job no longer runs `npm run lint` since the dedicated `lint` job already covers it

## Test plan

- [ ] Verify all three workflows pass on this PR
- [ ] Confirm only the action-io-generator workflow triggers (commit-data and bundle-verifier paths untouched)
- [ ] Merge and verify push-to-main triggers work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)