### PR TITLE
Update actions/setup-node from v4 to v7

### DIFF
--- a/.github/workflows/ci-action-io-generator.yml
+++ b/.github/workflows/ci-action-io-generator.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
       - run: npm ci
@@ -41,7 +41,7 @@ jobs:
       WORKDIR: "./action-io-generator"
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
 
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
 

--- a/.github/workflows/verify-verifier.yml
+++ b/.github/workflows/verify-verifier.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v7
       with:
         node-version: 24
 


### PR DESCRIPTION
## Summary

- Update `actions/setup-node` from v4 to v7 in all CI workflows
- v4 targets Node 20 which is deprecated on GitHub Actions runners, producing warnings on every CI run

## Test plan

- [ ] CI passes without Node 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)