### PR TITLE
Harden repository security: least-privilege workflows and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @snecklifter
+
+.github/ @snecklifter

--- a/.github/workflows/ci-action-io-generator.yml
+++ b/.github/workflows/ci-action-io-generator.yml
@@ -11,6 +11,9 @@ on:
       - 'action-io-generator/**'
       - '.github/workflows/ci-action-io-generator.yml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci-commit-data.yml
+++ b/.github/workflows/ci-commit-data.yml
@@ -10,6 +10,9 @@ on:
       - 'commit-data/**'
       - '.github/workflows/ci-commit-data.yml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/verify-verifier.yml
+++ b/.github/workflows/verify-verifier.yml
@@ -10,6 +10,9 @@ on:
       - 'bundle-verifier/**'
       - '.github/workflows/verify-verifier.yml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Add explicit `permissions: contents: read` to all three CI workflow files, following the principle of least privilege
- Add `.github/CODEOWNERS` to enforce review routing through `@snecklifter`

### Companion repo-level changes (already applied)

- Default workflow token permissions changed from `write` to `read`
- `can_approve_pull_request_reviews` disabled for the GITHUB_TOKEN
- Secret scanning and push protection enabled

## Test plan

- [ ] Verify CI workflows still pass with explicit read-only permissions
- [ ] Verify CODEOWNERS triggers review requests on new PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)